### PR TITLE
fix: follow-up review fixes (tempo guard, modulation dedup, SIMD reporting, Quantize/voice-leading perf)

### DIFF
--- a/src/Celeritas.CLI/Program.cs
+++ b/src/Celeritas.CLI/Program.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using System.Diagnostics;
 using System.Globalization;
+using System.Numerics;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using Celeritas.Core;
@@ -392,7 +393,16 @@ infoCommand.SetAction(parseResult =>
     Console.WriteLine($"Runtime: {Environment.Version}");
     Console.WriteLine();
     Console.WriteLine($"SIMD support: {SimdInfo.GetDescription()}");
-    Console.WriteLine($"Active tier:  {SimdInfo.GetBest()}");
+    Console.WriteLine($"Highest ISA:  {SimdInfo.GetBest()}");
+
+    // The compute kernels run on portable Vector<T>, whose width the JIT picks from the
+    // hardware — note that on AVX-512 machines .NET defaults Vector<T> to 256-bit unless
+    // DOTNET_PreferredVectorBitWidth=512 is set, so report the width actually in use rather
+    // than implying the highest ISA above is fully exercised.
+    var vectorBits = Vector<byte>.Count * 8;
+    Console.WriteLine(Vector.IsHardwareAccelerated
+        ? $"Active kernels: Vector<T> @ {vectorBits}-bit ({Vector<float>.Count} floats/op)"
+        : "Active kernels: scalar (no hardware SIMD)");
 });
 
 rootCommand.Subcommands.Add(infoCommand);

--- a/src/Celeritas/Core/Analysis/ModulationDetector.cs
+++ b/src/Celeritas/Core/Analysis/ModulationDetector.cs
@@ -92,7 +92,9 @@ public static class ModulationDetector
 
         var modulations = new List<ModulationEvent>();
         var currentKey = startKey;
-        var minModulationDuration = new Rational(2, 1); // At least 2 beats
+        // Whole-note time units (quarter = 1/4), so 2/1 is two whole notes (~two 4/4 bars,
+        // 8 quarter-beats). A foreign-key area shorter than this counts as a tonicization.
+        var minModulationDuration = new Rational(2, 1);
 
         // Convert to array for easier manipulation
         var notesArray = notes.ToArray();
@@ -139,12 +141,15 @@ public static class ModulationDetector
                 continue; // Not stable enough, probably just passing
             }
 
-            // Same target key detected on a contiguous run of indices: extend the
-            // run instead of emitting a duplicate event.
+            // Same target key still being detected within one analysis window of the last
+            // sighting: extend the run instead of emitting a duplicate. A tolerance of
+            // windowSize (rather than strict index adjacency) bridges the short gaps that
+            // occur when a single index dips below the stability threshold, while a genuine
+            // re-tonicization after a longer return home is still emitted as a new event.
             if (lastEmittedTarget is { } prevTarget
                 && prevTarget.Root == detectedKey.Value.Root
                 && prevTarget.IsMajor == detectedKey.Value.IsMajor
-                && i == lastEmittedIndex + 1)
+                && i - lastEmittedIndex <= windowSize)
             {
                 lastEmittedIndex = i;
                 continue;

--- a/src/Celeritas/Core/Midi/MidiIo.cs
+++ b/src/Celeritas/Core/Midi/MidiIo.cs
@@ -163,6 +163,19 @@ public static class MidiIo
 
         // Set tempo (optional but useful for DAWs).
         var tempo = Tempo.FromBeatsPerMinute(options.Bpm);
+
+        // A MIDI Set Tempo meta event stores microseconds-per-quarter in 24 bits, so only
+        // [1, 16_777_215] is representable. Guard the whole positive range (not just <= 0):
+        // a very small Bpm (~1-3) overflows that limit and a huge Bpm rounds it to 0, either
+        // of which would surface as a raw DryWetMidi failure or a degenerate tempo.
+        const long maxMicrosecondsPerQuarter = 0xFF_FF_FF; // 16_777_215
+        if (tempo.MicrosecondsPerQuarterNote is < 1 or > maxMicrosecondsPerQuarter)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options), options.Bpm,
+                $"Bpm {options.Bpm} maps to {tempo.MicrosecondsPerQuarterNote} µs/quarter, outside the MIDI-encodable " +
+                $"range [1, {maxMicrosecondsPerQuarter}] (roughly 4-60000000 BPM).");
+        }
+
         track.Events.Add(new SetTempoEvent(tempo.MicrosecondsPerQuarterNote));
 
         using var notesManager = track.ManageNotes();

--- a/src/Celeritas/Core/MusicMath.cs
+++ b/src/Celeritas/Core/MusicMath.cs
@@ -84,18 +84,39 @@ public static unsafe class MusicMath
         var gNum = grid.Numerator;
         var gDen = grid.Denominator;
 
+        // When the grid and an offset all fit in Int32, every intermediate below is bounded by
+        // ~2^62 and stays exact in Int64; only near-Int64 magnitudes need the 128-bit path.
+        // gNum > 0 (checked above) and gDen > 0 always.
+        var gridFitsInt32 = gNum <= int.MaxValue && gDen <= int.MaxValue;
+
         for (var i = 0; i < count; i++)
         {
-            // offset / grid = (num * gDen) / (den * gNum); Int128 makes the cross-products exact.
-            // Both den and gNum are positive, so valDen > 0 and floor division rounds half-up correctly
-            // for negative offsets too.
-            var valNum = (Int128)offsetsNum[i] * gDen;
-            var valDen = (Int128)offsetsDen[i] * gNum;
-            var shifted = valNum + (valDen >> 1);
-            var rounded = shifted >= 0
-                ? shifted / valDen
-                : -((-shifted + valDen - 1) / valDen);
-            offsetsNum[i] = checked((long)(rounded * gNum));
+            var offNum = offsetsNum[i];
+            var offDen = offsetsDen[i]; // always > 0
+
+            // offset / grid = (offNum * gDen) / (offDen * gNum). The divisor is positive, so
+            // floor division rounds half-up correctly for negative offsets too.
+            if (gridFitsInt32 && offNum is >= int.MinValue and <= int.MaxValue && offDen <= int.MaxValue)
+            {
+                var valNum = offNum * gDen;
+                var valDen = offDen * gNum;
+                var shifted = valNum + (valDen >> 1);
+                var rounded = shifted >= 0
+                    ? shifted / valDen
+                    : -((-shifted + valDen - 1) / valDen);
+                offsetsNum[i] = rounded * gNum;
+                offsetsDen[i] = gDen;
+                continue;
+            }
+
+            // Exact 128-bit fallback for pathological magnitudes.
+            var valNum128 = (Int128)offNum * gDen;
+            var valDen128 = (Int128)offDen * gNum;
+            var shifted128 = valNum128 + (valDen128 >> 1);
+            var rounded128 = shifted128 >= 0
+                ? shifted128 / valDen128
+                : -((-shifted128 + valDen128 - 1) / valDen128);
+            offsetsNum[i] = checked((long)(rounded128 * gNum));
             offsetsDen[i] = gDen;
         }
 

--- a/src/Celeritas/Core/VoiceLeading/VoiceLeadingRules.cs
+++ b/src/Celeritas/Core/VoiceLeading/VoiceLeadingRules.cs
@@ -42,6 +42,16 @@ public static class VoiceLeadingRules
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static VoiceLeadingCheck Check(Voicing from, Voicing to, int keyRoot = 0)
+        => Check(from, to, keyRoot, GetChordalSeventhPitchClass(from));
+
+    /// <summary>
+    /// Overload for hot paths (e.g. the DP solver) that evaluate many 'to' candidates against
+    /// the same 'from': the chordal-seventh pitch class of 'from' depends only on 'from', so it
+    /// can be computed once per source voicing and reused instead of re-running chord
+    /// identification for every candidate. Pass the result of
+    /// <see cref="GetChordalSeventhPitchClass"/> for <paramref name="fromChordalSeventhPc"/>.
+    /// </summary>
+    internal static VoiceLeadingCheck Check(Voicing from, Voicing to, int keyRoot, int fromChordalSeventhPc)
     {
         var violations = VoiceLeadingViolation.None;
 
@@ -61,7 +71,7 @@ public static class VoiceLeadingRules
         violations |= CheckSpacing(to);
 
         // Check resolution rules (leading tone, seventh)
-        violations |= CheckResolutions(from, to, keyRoot);
+        violations |= CheckResolutions(from, to, keyRoot, fromChordalSeventhPc);
 
         // Check doubling
         violations |= CheckDoubling(to, keyRoot);
@@ -229,15 +239,13 @@ public static class VoiceLeadingRules
     /// Check resolution of tendency tones (leading tone, chordal seventh).
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static VoiceLeadingViolation CheckResolutions(Voicing from, Voicing to, int keyRoot)
+    private static VoiceLeadingViolation CheckResolutions(Voicing from, Voicing to, int keyRoot, int seventhPc)
     {
         var violations = VoiceLeadingViolation.None;
         var leadingTone = (keyRoot + 11) % 12; // 7th scale degree
 
-        // Identify the chordal seventh of the 'from' chord (if it is a seventh chord),
-        // so we can require it to resolve down by step.
-        var seventhPc = GetChordalSeventhPitchClass(from);
-
+        // seventhPc is the chordal seventh of the 'from' chord (or -1 if it is not a seventh
+        // chord), precomputed by the caller so it can be reused across many 'to' candidates.
         for (var v = 0; v < 4; v++)
         {
             var voice = (Voice)v;
@@ -278,9 +286,11 @@ public static class VoiceLeadingRules
 
     /// <summary>
     /// Returns the pitch class of the chordal seventh of the voicing's chord,
-    /// or -1 if the voicing is not recognized as a seventh chord.
+    /// or -1 if the voicing is not recognized as a seventh chord. Exposed for callers that
+    /// reuse it across many transitions from the same source voicing (see the
+    /// <see cref="Check(Voicing, Voicing, int, int)"/> overload).
     /// </summary>
-    private static int GetChordalSeventhPitchClass(Voicing voicing)
+    internal static int GetChordalSeventhPitchClass(Voicing voicing)
     {
         Span<int> pitches = [voicing.Bass, voicing.Tenor, voicing.Alto, voicing.Soprano];
         var info = ChordAnalyzer.Identify(pitches);

--- a/src/Celeritas/Core/VoiceLeading/VoiceLeadingSolver.cs
+++ b/src/Celeritas/Core/VoiceLeading/VoiceLeadingSolver.cs
@@ -195,6 +195,13 @@ public sealed class VoiceLeadingSolver(VoiceLeadingSolverOptions? options = null
             var prevCosts = costs[i - 1];
             var currentPrev = prev[i];
 
+            // The chordal seventh of each 'from' voicing depends only on that voicing, so
+            // compute it once per source here instead of re-identifying the chord inside every
+            // one of the O(current x prev) transition-cost evaluations below.
+            var prevSeventhPcs = new int[prevVoicings.Length];
+            for (var k = 0; k < prevVoicings.Length; k++)
+                prevSeventhPcs[k] = VoiceLeadingRules.GetChordalSeventhPitchClass(prevVoicings[k]);
+
             // Parallel if enough work
             if (currentVoicings.Length * prevVoicings.Length > 1000)
             {
@@ -209,7 +216,7 @@ public sealed class VoiceLeadingSolver(VoiceLeadingSolverOptions? options = null
                         if (prevCosts[k] >= float.MaxValue) continue;
 
                         var prevV = prevVoicings[k];
-                        var transitionCost = ComputeTransitionCost(prevV, current, keyRoot);
+                        var transitionCost = ComputeTransitionCost(prevV, current, keyRoot, prevSeventhPcs[k]);
 
                         if (transitionCost >= _options.MaxTransitionCost) continue;
 
@@ -237,7 +244,7 @@ public sealed class VoiceLeadingSolver(VoiceLeadingSolverOptions? options = null
                         if (prevCosts[k] >= float.MaxValue) continue;
 
                         var prevV = prevVoicings[k];
-                        var transitionCost = ComputeTransitionCost(prevV, current, keyRoot);
+                        var transitionCost = ComputeTransitionCost(prevV, current, keyRoot, prevSeventhPcs[k]);
 
                         if (transitionCost >= _options.MaxTransitionCost) continue;
 
@@ -303,9 +310,9 @@ public sealed class VoiceLeadingSolver(VoiceLeadingSolverOptions? options = null
     /// Compute the cost of transitioning between two voicings.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private float ComputeTransitionCost(Voicing from, Voicing to, int keyRoot)
+    private float ComputeTransitionCost(Voicing from, Voicing to, int keyRoot, int fromChordalSeventhPc)
     {
-        var check = VoiceLeadingRules.Check(from, to, keyRoot);
+        var check = VoiceLeadingRules.Check(from, to, keyRoot, fromChordalSeventhPc);
 
         // If hard violations, return very high cost
         if (_options.StrictMode && !check.IsValid)

--- a/tests/Celeritas.Tests/MidiIoTests.cs
+++ b/tests/Celeritas.Tests/MidiIoTests.cs
@@ -70,6 +70,34 @@ public class MidiIoTests
     }
 
     [Fact]
+    public void Export_BpmBelowMidiEncodableRange_ThrowsArgumentOutOfRange()
+    {
+        using var buffer = new NoteBuffer(1);
+        buffer.AddNote(60, Rational.Zero, Rational.Quarter);
+        using var ms = new MemoryStream();
+
+        // Bpm 3 maps to 20,000,000 µs/quarter, above the 24-bit Set Tempo limit (16,777,215).
+        // This must surface as a friendly ArgumentOutOfRangeException, not a raw library failure.
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => MidiIo.Export(buffer, ms, new MidiExportOptions(Bpm: 3)));
+        Assert.Equal("options", ex.ParamName);
+    }
+
+    [Fact]
+    public void Export_LowestMidiEncodableBpm_RoundTrips()
+    {
+        using var buffer = new NoteBuffer(1);
+        buffer.AddNote(60, Rational.Zero, Rational.Quarter);
+        using var ms = new MemoryStream();
+
+        // Bpm 4 maps to 15,000,000 µs/quarter, just within the encodable range.
+        MidiIo.Export(buffer, ms, new MidiExportOptions(Bpm: 4));
+        ms.Position = 0;
+        using var imported = MidiIo.Import(ms);
+        Assert.Equal(1, imported.Count);
+    }
+
+    [Fact]
     public void Import_MaxNotesZero_ReturnsEmptyBuffer()
     {
         using var source = new NoteBuffer(2);

--- a/tests/Celeritas.Tests/MusicMathTests.cs
+++ b/tests/Celeritas.Tests/MusicMathTests.cs
@@ -160,4 +160,17 @@ public class MusicMathTests
         Assert.Equal(new Rational(1, 2), offset2); // 2/4 -> 1/2
         Assert.Equal(new Rational(3, 4), offset3); // 3/4
     }
+
+    [Fact]
+    public void Quantize_ExtremeMagnitudeOffset_UsesExactFallbackPath()
+    {
+        // An offset numerator beyond Int32 forces Quantize's 128-bit fallback path.
+        // 5e9/3 on a 1/4 grid: (5e9 * 4) / 3 = 20e9/3, round-half-up -> 6,666,666,667 quarter units.
+        using var buffer = new NoteBuffer(1);
+        buffer.AddNote(60, new Rational(5_000_000_000L, 3), Rational.Quarter);
+
+        MusicMath.Quantize(buffer, Rational.Quarter);
+
+        Assert.Equal(new Rational(6_666_666_667L, 4), buffer.GetOffset(0));
+    }
 }


### PR DESCRIPTION
Follow-up to #1 resolving the six non-blocking findings surfaced during that PR's review.

## Correctness / robustness

- **MIDI tempo guard** (`MidiIo.Export`) — previously only `Bpm <= 0` was rejected. A MIDI Set Tempo meta event stores microseconds-per-quarter in 24 bits, so a tiny Bpm (~1-3) overflowed that limit into a raw DryWetMidi failure, and an enormous Bpm rounded it to a degenerate 0. The resulting tempo is now validated across the whole range with a friendly `ArgumentOutOfRangeException`.
- **Modulation detector** — the `minModulationDuration` comment said "2 beats" but under the whole-note time convention `2/1` is two whole notes (8 quarter-beats); comment corrected. Tonicization dedup coalesced only strictly adjacent indices, so a single index dipping below the stability threshold re-emitted a duplicate event; it now coalesces within one analysis window while still emitting a genuine re-tonicization after a longer return home.
- **CLI `info`** — printed `Active tier: {highest ISA}`, implying that ISA was fully exercised. The kernels run on portable `Vector<T>`, which .NET defaults to 256-bit on AVX-512 hardware unless `DOTNET_PreferredVectorBitWidth=512`. It now reports the highest ISA and the actual `Vector<T>` width separately (e.g. `Highest ISA: Avx512F` + `Active kernels: Vector<T> @ 256-bit`).

## Performance

- **Quantize** — used Int128 cross-multiplication for every element. When the grid and offset all fit in Int32 every intermediate stays exact in Int64, so it now takes a 64-bit fast path and falls back to Int128 only for near-Int64 magnitudes. Results are identical.
- **Voice leading** — `CheckResolutions` re-ran `ChordAnalyzer.Identify` on the source voicing, so the DP solver re-identified the same source chord for every candidate transition in its O(current × prev) inner loop. An internal `Check` overload now accepts a precomputed chordal-seventh pitch class, and the solver computes it once per source voicing and reuses it.

The public API and all results are unchanged. 543/543 tests pass (3 new), build is clean with 0 warnings under `TreatWarningsAsErrors`.
